### PR TITLE
Updates magento2 template stack

### DIFF
--- a/environments/magento2/devenv.nix
+++ b/environments/magento2/devenv.nix
@@ -52,7 +52,7 @@ in {
     # PHP
     languages.php = {
         enable = true;
-        package = inputs.phps.packages.${builtins.currentSystem}.php81.buildEnv {
+        package = inputs.phps.packages.${builtins.currentSystem}.php82.buildEnv {
             extensions = { all, enabled }: with all; enabled ++ [ redis xdebug xsl ];
             extraConfig = ''
                 memory_limit = -1
@@ -87,7 +87,7 @@ in {
     # JS
     languages.javascript = {
         enable = true;
-        package = pkgs.nodejs-16_x;
+        package = pkgs.nodejs_20;
     };
 
     # nginx


### PR DESCRIPTION
Hi @mwr, this MR updates the PHP version from `8.1` to `8.2` and the NodeJs version.

Please note that the `pkgs.nodejs-16_x;` package is no longer available. The LTS version is sent as the update.