### PR TITLE
Adds PROJECT_TLD variable to the Nginx allowed variables

### DIFF
--- a/src/Cli/Command/Nginx/InitNginxCommand.php
+++ b/src/Cli/Command/Nginx/InitNginxCommand.php
@@ -22,6 +22,7 @@ class InitNginxCommand extends Command
         'NGINX_PKG_ROOT',
         'PROJECT_NAME',
         'PROJECT_HOST',
+        'PROJECT_TLD',
         'HOME',
     ];
 


### PR DESCRIPTION
Without this variable, Nginx will not start if we use the custom TLD Nginx template.

An example of the error:

![image](https://github.com/run-as-root/rooter/assets/5084933/f5cd0c2c-2203-44c9-850e-4b0f1f2f501a)
