### PR TITLE
Increases the timeout for mysql:dump command

### DIFF
--- a/src/Cli/Command/Mysql/MysqlDumpCommand.php
+++ b/src/Cli/Command/Mysql/MysqlDumpCommand.php
@@ -28,7 +28,7 @@ class MysqlDumpCommand extends Command
 
         $output->writeln($command);
 
-        $exitCode = Process::fromShellCommandline($command)->setTty(true)->run();
+        $exitCode = Process::fromShellCommandline(command: $command, timeout: 120)->setTty(true)->run();
 
         $output->writeln("dumped to $dumpFile");
 

--- a/src/Cli/Command/Mysql/MysqlDumpCommand.php
+++ b/src/Cli/Command/Mysql/MysqlDumpCommand.php
@@ -5,15 +5,19 @@ namespace RunAsRoot\Rooter\Cli\Command\Mysql;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 
 class MysqlDumpCommand extends Command
 {
+    private const DEFAULT_DB_CMD_TIMEOUT = 360;
+
     public function configure()
     {
         $this->setName('mysql:dump');
         $this->setDescription('dump mysql database');
+        $this->addOption('timeout', 't', InputOption::VALUE_REQUIRED, 'timeout in seconds');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -22,13 +26,14 @@ class MysqlDumpCommand extends Command
         $pass = getenv('DEVENV_DB_PASS');
         $port = getenv('DEVENV_DB_PORT');
         $db = getenv('DEVENV_DB_NAME');
+        $timeout = getenv('DEVENV_DB_CMD_TIMEOUT') ?: self::DEFAULT_DB_CMD_TIMEOUT;
 
         $dumpFile = sprintf("dump-%s.sql", time());
         $command = "mysqldump -u$user -p$pass --host=127.0.0.1 --port=$port $db > $dumpFile";
 
         $output->writeln($command);
 
-        $exitCode = Process::fromShellCommandline(command: $command, timeout: 120)->setTty(true)->run();
+        $exitCode = Process::fromShellCommandline(command: $command, timeout: $timeout)->setTty(true)->run();
 
         $output->writeln("dumped to $dumpFile");
 


### PR DESCRIPTION
Hi @mwr, I sent the change to increase the timeout for the `mysql:dump` command.

The default value is 60 seconds, and it was doubled to 120 seconds.

It is necessary when we're exporting large databases.